### PR TITLE
more pythonic dict key comparison, also Python3 compatible

### DIFF
--- a/join_forum_data/join_forum_data.py
+++ b/join_forum_data/join_forum_data.py
@@ -99,7 +99,7 @@ with open('coarse_discourse_dataset.json') as jsonfile:
 
         found_count = 0
         for post in reader['posts']:
-            if not post.has_key('body'):
+            if not 'body' in post.keys():
                 print("Can't find %s in URL: %s" % (post['id'], reader['url']))
             else:
                 found_count += 1


### PR DESCRIPTION
The `has_key()` method was [discontinued in Python 3.x](https://docs.python.org/3.1/whatsnew/3.0.html#builtins), so I rewrote the verification for not found posts using the `in` operator, which was included in Python 2.3.